### PR TITLE
Prevent KGP from automatically adding the stdlib

### DIFF
--- a/inflation-inject/gradle.properties
+++ b/inflation-inject/gradle.properties
@@ -1,3 +1,5 @@
 POM_NAME=Inflation Inject Runtime
 POM_ARTIFACT_ID=inflation-inject
 POM_PACKAGING=jar
+
+kotlin.stdlib.default.dependency=false


### PR DESCRIPTION
This module is written in Java. Only its tests use Kotlin and they have an explicit stdlib dep.

Closes #168 